### PR TITLE
Add GSM8K dataset and random filtering option

### DIFF
--- a/automatic_run.py
+++ b/automatic_run.py
@@ -1,11 +1,11 @@
 # run model_training.py multiple times with different run parameters
 import subprocess
 
-TASK = ["rte"]
+TASK = ["gsm8k_main"]
 MODES = ["llama_3_100"]
 RUNS = ["1"]
 MODELCLASS = "default"
-ACTIVELEARNING = ["None"]
+ACTIVELEARNING = ["random_filtering"]
 WARMSTART = ""
 
 # TASK = ["sst2_25_cont_index_recap_2"] # continous sampling naming: sst2_25_cont_index_recap_4 -> 25 samples, start with 4th iteration (after 100 instances)

--- a/prompt_generation.py
+++ b/prompt_generation.py
@@ -449,6 +449,12 @@ def read_dataset(shuffled=False):
                             "label": "label",
                         }
                     )
+            elif TASK == "gsm8k_main":
+                dataset = load_dataset("gsm8k", "main")
+                df_train = dataset["train"].to_pandas()
+                df_train = df_train.rename(
+                    columns={"question": "text", "answer": "label"}
+                )
             else:
                 dataset = load_dataset("SetFit/" + TASK)
                 # convert to pandas dataframe


### PR DESCRIPTION
## Summary
- load the GSM8K `main` split when needed
- fall back to HuggingFace for GSM8K data in training
- support a `random_filtering` active learning option
- update automatic_run example to use the new dataset and strategy

## Testing
- `python -m py_compile prompt_generation.py model_training.py automatic_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68510f8bf0388320b9c3a49a21165c55